### PR TITLE
统一Multi Get函数命名规则

### DIFF
--- a/hset.go
+++ b/hset.go
@@ -248,6 +248,57 @@ func (this *Client) MultiHgetSliceArray(setName string, key []string) (keys []st
 	return nil, nil, makeError(resp, key)
 }
 
+//批量获取 hashmap 中全部 对应的权重值.
+//
+//  setName - hashmap 的名字.
+//  keys - 包含 key 的数组 .
+//  返回 包含 key-value 的关联数组, 如果某个 key 不存在, 则它不会出现在返回数组中.
+//  返回 err，执行的错误，操作成功返回 nil
+func (this *Client) MultiHgetAll(setName string) (val map[string]Value, err error) {
+
+	resp, err := this.Do("hgetall", setName)
+
+	if err != nil {
+		return nil, goerr.NewError(err, "MultiHgetAll %s error", setName)
+	}
+	size := len(resp)
+	if size > 0 && resp[0] == "ok" {
+		val = make(map[string]Value)
+		for i := 1; i < size && i+1 < size; i += 2 {
+			val[resp[i]] = Value(resp[i+1])
+		}
+		return val, nil
+	}
+	return nil, makeError(resp)
+}
+
+//批量获取 hashmap 中全部 对应的权重值.
+//
+//  setName - hashmap 的名字.
+//  keys - 包含 key 的数组 .
+//  返回 包含 key和value 的有序数组, 如果某个 key 不存在, 则它不会出现在返回数组中.
+//  返回 err，执行的错误，操作成功返回 nil
+func (this *Client) MultiHgetAllSlice(setName string) (keys []string, values []Value, err error) {
+
+	resp, err := this.Do("hgetall", setName)
+
+	if err != nil {
+		return nil, nil, goerr.NewError(err, "MultiHgetAllSlice %s error", setName)
+	}
+	if len(resp) > 0 && resp[0] == "ok" {
+		size := len(resp)
+		keys := make([]string, 0, (size-1)/2)
+		values := make([]Value, 0, (size-1)/2)
+
+		for i := 1; i < size && i+1 < size; i += 2 {
+			keys = append(keys, resp[i])
+			values = append(values, Value(resp[i+1]))
+		}
+		return keys, values, nil
+	}
+	return nil, nil, makeError(resp)
+}
+
 //批量删除 hashmap 中的 key.
 //
 //  setName - hashmap 的名字.

--- a/hset.go
+++ b/hset.go
@@ -193,6 +193,61 @@ func (this *Client) MultiHgetSlice(setName string, key ...string) (keys []string
 	return nil, nil, makeError(resp, key)
 }
 
+//批量获取 hashmap 中多个 key 对应的权重值.（输入分片）
+//
+//  setName - hashmap 的名字.
+//  keys - 包含 key 的数组 .
+//  返回 包含 key-value 的关联数组, 如果某个 key 不存在, 则它不会出现在返回数组中.
+//  返回 err，执行的错误，操作成功返回 nil
+func (this *Client) MultiHgetArray(setName string, key []string) (val map[string]Value, err error) {
+	if len(key) == 0 {
+		return make(map[string]Value), nil
+	}
+	resp, err := this.Do("multi_hget", setName, key)
+
+	if err != nil {
+		return nil, goerr.NewError(err, "MultiHget %s %s error", setName, key)
+	}
+	size := len(resp)
+	if size > 0 && resp[0] == "ok" {
+		val = make(map[string]Value)
+		for i := 1; i < size && i+1 < size; i += 2 {
+			val[resp[i]] = Value(resp[i+1])
+		}
+		return val, nil
+	}
+	return nil, makeError(resp, key)
+}
+
+//批量获取 hashmap 中多个 key 对应的权重值.（输入分片）
+//
+//  setName - hashmap 的名字.
+//  keys - 包含 key 的数组 .
+//  返回 包含 key和value 的有序数组, 如果某个 key 不存在, 则它不会出现在返回数组中.
+//  返回 err，执行的错误，操作成功返回 nil
+func (this *Client) MultiHgetSliceArray(setName string, key []string) (keys []string, values []Value, err error) {
+	if len(key) == 0 {
+		return []string{}, []Value{}, nil
+	}
+	resp, err := this.Do("multi_hget", setName, key)
+
+	if err != nil {
+		return nil, nil, goerr.NewError(err, "MultiHgetSlice %s %s error", setName, key)
+	}
+	if len(resp) > 0 && resp[0] == "ok" {
+		size := len(resp)
+		keys := make([]string, 0, (size-1)/2)
+		values := make([]Value, 0, (size-1)/2)
+
+		for i := 1; i < size && i+1 < size; i += 2 {
+			keys = append(keys, resp[i])
+			values = append(values, Value(resp[i+1]))
+		}
+		return keys, values, nil
+	}
+	return nil, nil, makeError(resp, key)
+}
+
 //批量删除 hashmap 中的 key.
 //
 //  setName - hashmap 的名字.

--- a/set.go
+++ b/set.go
@@ -242,6 +242,62 @@ func (this *Client) MultiGetSlice(key ...string) (keys []string, values []Value,
 	return nil, nil, makeError(resp, key)
 }
 
+//批量获取一批 key 对应的值内容.（输入分片）
+//
+//  key，要获取的 key，可以为多个
+//  返回 val，一个包含返回的 map
+//  返回 err，可能的错误，操作成功返回 nil
+func (this *Client) MultiGetArray(key []string) (val map[string]Value, err error) {
+	if len(key) == 0 {
+		return make(map[string]Value), nil
+	}
+	resp, err := this.Do("multi_get", key)
+
+	if err != nil {
+		return nil, goerr.NewError(err, "MultiGet %s error", key)
+	}
+
+	size := len(resp)
+	if size > 0 && resp[0] == "ok" {
+		val = make(map[string]Value)
+		for i := 1; i < size && i+1 < size; i += 2 {
+			val[resp[i]] = Value(resp[i+1])
+		}
+		return val, nil
+	}
+	return nil, makeError(resp, key)
+}
+
+//批量获取一批 key 对应的值内容.（输入分片）
+//
+//  key，要获取的 key，可以为多个
+//  返回 keys和value分片
+//  返回 err，可能的错误，操作成功返回 nil
+func (this *Client) MultiGetSliceArray(key []string) (keys []string, values []Value, err error) {
+	if len(key) == 0 {
+		return []string{}, []Value{}, nil
+	}
+	resp, err := this.Do("multi_get", key)
+
+	if err != nil {
+		return nil, nil, goerr.NewError(err, "MultiGet %s error", key)
+	}
+
+	size := len(resp)
+	if size > 0 && resp[0] == "ok" {
+
+		keys := make([]string, 0, (size-1)/2)
+		values := make([]Value, 0, (size-1)/2)
+
+		for i := 1; i < size && i+1 < size; i += 2 {
+			keys = append(keys, resp[i])
+			values = append(values, Value(resp[i+1]))
+		}
+		return keys, values, nil
+	}
+	return nil, nil, makeError(resp, key)
+}
+
 //批量删除一批 key 和其对应的值内容.
 //
 //  key，要删除的 key，可以为多个

--- a/set.go
+++ b/set.go
@@ -212,6 +212,36 @@ func (this *Client) MultiGet(key ...string) (val map[string]Value, err error) {
 	return nil, makeError(resp, key)
 }
 
+//批量获取一批 key 对应的值内容.
+//
+//  key，要获取的 key，可以为多个
+//  返回 keys和value分片
+//  返回 err，可能的错误，操作成功返回 nil
+func (this *Client) MultiGetSlice(key ...string) (keys []string, values []Value, err error) {
+	if len(key) == 0 {
+		return []string{}, []Value{}, nil
+	}
+	resp, err := this.Do("multi_get", key)
+
+	if err != nil {
+		return nil, nil, goerr.NewError(err, "MultiGet %s error", key)
+	}
+
+	size := len(resp)
+	if size > 0 && resp[0] == "ok" {
+
+		keys := make([]string, 0, (size-1)/2)
+		values := make([]Value, 0, (size-1)/2)
+
+		for i := 1; i < size && i+1 < size; i += 2 {
+			keys = append(keys, resp[i])
+			values = append(values, Value(resp[i+1]))
+		}
+		return keys, values, nil
+	}
+	return nil, nil, makeError(resp, key)
+}
+
 //批量删除一批 key 和其对应的值内容.
 //
 //  key，要删除的 key，可以为多个

--- a/zset.go
+++ b/zset.go
@@ -169,6 +169,50 @@ func (this *Client) MultiZgetSlice(setName string, key ...string) (keys []string
 	return nil, nil, makeError(resp, setName, key)
 }
 
+func (this *Client) MultiZgetArray(setName string, key []string) (val map[string]int64, err error) {
+	if len(key) == 0 {
+		return make(map[string]int64), nil
+	}
+	resp, err := this.Do("multi_zget", setName, key)
+
+	if err != nil {
+		return nil, goerr.NewError(err, "MultiZget %s %s error", setName, key)
+	}
+	size := len(resp)
+	if size > 0 && resp[0] == "ok" {
+		val = make(map[string]int64)
+		for i := 1; i < size && i+1 < size; i += 2 {
+			val[resp[i]] = Value(resp[i+1]).Int64()
+		}
+		return val, nil
+	}
+	return nil, makeError(resp, key)
+}
+func (this *Client) MultiZgetSliceArray(setName string, key []string) (keys []string, scores []int64, err error) {
+	if len(key) == 0 {
+		return []string{}, []int64{}, nil
+	}
+	resp, err := this.Do("multi_zget", setName, key)
+
+	if err != nil {
+		return nil, nil, goerr.NewError(err, "MultiZget %s %s error", setName, key)
+	}
+
+	size := len(resp)
+	if size > 0 && resp[0] == "ok" {
+
+		keys := make([]string, (size-1)/2)
+		scores := make([]int64, (size-1)/2)
+
+		for i := 1; i < size && i+1 < size; i += 2 {
+			keys = append(keys, resp[i])
+			scores = append(scores, Value(resp[i+1]).Int64())
+		}
+		return keys, scores, nil
+	}
+	return nil, nil, makeError(resp, setName, key)
+}
+
 func (this *Client) MultiZdel(setName string, key ...string) (err error) {
 	if len(key) == 0 {
 		return nil

--- a/zset.go
+++ b/zset.go
@@ -125,7 +125,7 @@ func (this *Client) MultiZset(setName string, kvs map[string]int64) (err error) 
 	return makeError(resp, setName, kvs)
 }
 
-func (this *Client) MultiZgetMap(setName string, key ...string) (val map[string]int64, err error) {
+func (this *Client) MultiZget(setName string, key ...string) (val map[string]int64, err error) {
 	if len(key) == 0 {
 		return make(map[string]int64), nil
 	}
@@ -144,7 +144,7 @@ func (this *Client) MultiZgetMap(setName string, key ...string) (val map[string]
 	}
 	return nil, makeError(resp, key)
 }
-func (this *Client) MultiZget(setName string, key ...string) (keys []string, scores []int64, err error) {
+func (this *Client) MultiZgetSlice(setName string, key ...string) (keys []string, scores []int64, err error) {
 	if len(key) == 0 {
 		return []string{}, []int64{}, nil
 	}


### PR DESCRIPTION
更具set.go，hset.go的Multi Get 方法命名规则，命名带Slice后缀为获取数组形式，不待后缀的为获取map形式