### PR TITLE
qrange bugfix

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -232,7 +232,7 @@ func (this *Client) slice(name string, args ...int) (v []Value, err error) {
 		return nil, goerr.NewError(err, "%s %s error", qslice_cmd[index], name)
 	}
 	size := len(resp)
-	if size > 1 && resp[0] == "ok" {
+	if size >= 1 && resp[0] == "ok" {
 		for i := 1; i < size; i++ {
 			v = append(v, Value(resp[i]))
 		}


### PR DESCRIPTION
数组为空时，返回的列表长度为0，属正常行为，若size > 1，会返回error