### PR TITLE
Update ssdbclient.go

### DIFF
--- a/ssdbclient.go
+++ b/ssdbclient.go
@@ -209,7 +209,15 @@ func (s *SSDBClient) Recv() (resp []string, err error) {
 		if packetSize == -1 {
 			packetSize = ToNum(buf[:(bufSize - drop)])
 		} else {
-			if s.packetBuf.Len()+bufSize == packetSize+drop {
+			//data endwith '\n' or '\r\n',
+			drop = 0
+			if s.packetBuf.Len()+bufSize == packetSize+1 { //
+				drop = 1
+			}
+			if s.packetBuf.Len()+bufSize == packetSize+2 {
+				drop = 2
+			}
+			if drop > 0 {
 				s.packetBuf.Write(buf[:bufSize-drop])
 				resp = append(resp, s.packetBuf.String())
 				s.packetBuf.Reset()


### PR DESCRIPTION
当数据以 0x0d 结尾时(buf[bufSize-2] == '\r')，数据块无法解析。
数据范例：
```
32 38 0a f0 01 00 00 00 00 00 00 03 0a 71 08 74 
74 74 74 31 31 31 31 40 00 00 00 00 00 00 0d 0a 
35 0a 73 73 73 31 35 0a 0a 
```
 解析到‘ 0d 0a ’时，
```
s.packetBuf.Len()=10 
bufSize=19
packetSize=28
drop=2
```
此时无法正常结束。


