### PR TITLE
MultiZGetSlice 出现和keys一样多的空字符串

### DIFF
--- a/client/zset.go
+++ b/client/zset.go
@@ -252,8 +252,8 @@ func (c *Client) MultiZGetSlice(setName string, key ...string) (keys []string, s
 	size := len(resp)
 	if size > 0 && resp[0] == oK {
 
-		keys := make([]string, (size-1)/2)
-		scores := make([]int64, (size-1)/2)
+		keys := make([]string, 0)
+		scores := make([]int64, 0)
 
 		for i := 1; i < size && i+1 < size; i += 2 {
 			keys = append(keys, resp[i])


### PR DESCRIPTION
提前分配了空间, keys/scores 都会多一倍的空字符串